### PR TITLE
add killExistingPrismaQueryEngineProcess;fixed bug

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,8 @@
 name: Go
 
 on:
+  workflow_dispatch:
+
   push:
     branches: [ main ]
   pull_request:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -10,12 +10,13 @@ import (
 	"sync"
 	"time"
 
+	"wunderbase/pkg/graphiql"
+
 	"github.com/buger/jsonparser"
 	"github.com/wundergraph/graphql-go-tools/pkg/astparser"
 	"github.com/wundergraph/graphql-go-tools/pkg/asttransform"
 	"github.com/wundergraph/graphql-go-tools/pkg/introspection"
 	"go.uber.org/ratelimit"
-	"wunderbase/pkg/graphiql"
 )
 
 type Handler struct {
@@ -32,10 +33,10 @@ type Handler struct {
 	cancel            func()
 }
 
-func NewHandler(enableSleepMode bool, enablePlayground bool, queryEngineURL string, queryEngineSdlURL string, sleepAfterSeconds, readLimitSeconds, writeLimitSeconds int, cancel func()) *Handler {
+func NewHandler(enableSleepMode bool, production bool, queryEngineURL string, queryEngineSdlURL string, sleepAfterSeconds, readLimitSeconds, writeLimitSeconds int, cancel func()) *Handler {
 	return &Handler{
 		enableSleepMode:   enableSleepMode,
-		enablePlayground:  enablePlayground,
+		enablePlayground:  !production,
 		queryEngineURL:    queryEngineURL,
 		queryEngineSdlURL: queryEngineSdlURL,
 		sleepCh:           make(chan struct{}),

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -17,7 +17,7 @@ func TestApi(t *testing.T) {
 
 	_, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	handler := NewHandler(false, true, fakeDB.URL, fakeDB.URL+"/sdl", 0, 10000, 2000, cancel)
+	handler := NewHandler(false, false, fakeDB.URL, fakeDB.URL+"/sdl", 0, 10000, 2000, cancel)
 
 	fakeAPI := httptest.NewServer(handler)
 

--- a/pkg/queryengine/queryengine.go
+++ b/pkg/queryengine/queryengine.go
@@ -2,13 +2,22 @@ package queryengine
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
+	"runtime"
 	"sync"
+	"syscall"
 )
 
 func Run(ctx context.Context, wg *sync.WaitGroup, queryEnginePath, queryEnginePort, prismaSchemaFilePath string, enablePlayground bool) {
+	// when start prisma query engine ,
+	// we're not able to listen on the same port,
+	// if last engine instance still alive.
+	// so we must kill the existing engine process before we start new onw.
+	killExistingyEngineProcess(queryEnginePort)
+
 	args := []string{"--datamodel-path", prismaSchemaFilePath}
 	if enablePlayground {
 		args = append(args, "--enable-playground", "--port", queryEnginePort)
@@ -27,4 +36,32 @@ func Run(ctx context.Context, wg *sync.WaitGroup, queryEnginePath, queryEnginePo
 	}
 	log.Println("Query Engine stopped")
 	wg.Done()
+}
+
+// reference:https://github.com/wundergraph/wundergraph
+func killExistingyEngineProcess(queryEnginePort string) {
+	if runtime.GOOS == "windows" {
+		command := fmt.Sprintf("(Get-NetTCPConnection -LocalPort %s).OwningProcess -Force", queryEnginePort)
+		execCmd(exec.Command("Stop-Process", "-Id", command))
+	} else {
+		command := fmt.Sprintf("lsof -i tcp:%s | grep LISTEN | awk '{print $2}' | xargs kill -9", queryEnginePort)
+		execCmd(exec.Command("bash", "-c", command))
+	}
+}
+
+func execCmd(cmd *exec.Cmd) {
+	var waitStatus syscall.WaitStatus
+	if err := cmd.Run(); err != nil {
+		if err != nil {
+			os.Stderr.WriteString(fmt.Sprintf("Error: %s\n", err.Error()))
+		}
+		if exitError, ok := err.(*exec.ExitError); ok {
+			waitStatus = exitError.Sys().(syscall.WaitStatus)
+			log.Println("Error during port killing (exit code: )", []byte(fmt.Sprintf("%d", waitStatus.ExitStatus())))
+		}
+	} else {
+		waitStatus = cmd.ProcessState.Sys().(syscall.WaitStatus)
+
+		log.Println("Successfully killed existing prisma query process", []byte(fmt.Sprintf("%d", waitStatus.ExitStatus())))
+	}
 }


### PR DESCRIPTION
when start prisma query engine ,we're not able to listen on the same port, if last engine instance still alive.
So we must kill the existing engine process before we start new onw.